### PR TITLE
Delete previously-fetched items from the DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,16 @@ what it should do when errors are found.
 - `log_link_error`: write to the console if a link is nullish.
 - `maximum_downloads`: if the number of fetched items is above this number, the
   fetching process will be stopped
-  - The `get_array_after_scroll` variable must be set to true
+  - The `get_array_after_scroll` variable must be set to false
   - If more items than this number can be fetched without continuing scrolling,
     they'll also be added. Therefore, the output number might be greater than
     this variable.
+- `delete_from_dom`: Delete the previous items form the DOM, so that
+  performances can be improved. Note that this is experimental and might break
+  TikTok's webpage in the future. Therefore, use it only if you need to (for big
+  pages)
+  - Remember to set the `get_array_after_scroll` variable to false. Otherwise,
+    this value will be ignored.
 
 ## Warning:
 

--- a/extension/code/manifest.json
+++ b/extension/code/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "tiktok-to-ytdlp",
   "description": "Get a .txt file of all the TikTok videos from an user/audio/hashtag/liked videos/saved videos etc, so that they can be downloaded with yt-dlp.",
-  "version": "1.1",
+  "version": "1.2",
   "permissions": ["storage"],
   "action": {
     "default_popup": "./ui/index.html"

--- a/extension/code/vite/src/lib/Settings/Advanced.svelte
+++ b/extension/code/vite/src/lib/Settings/Advanced.svelte
@@ -54,9 +54,23 @@
                 <input
                     type="checkbox"
                     bind:checked={$Settings.advanced.get_array_after_scroll}
-                /> Get the array after each scroll, instead of getting it at the
-                end
-            </label>
+                /> Get the array at the end, instead of getting it after each scroll
+            </label><br />
+            {#if !$Settings.advanced.get_array_after_scroll}
+                <label
+                    class="flex hcenter autoGap"
+                    in:slide={{ duration: 200 }}
+                    out:slide={{ duration: 200 }}
+                >
+                    <input
+                        type="checkbox"
+                        bind:checked={$Settings.advanced.delete_from_dom}
+                    />
+                    Automatically delete items from the DOM, so that page performances
+                    can be improved. [Experimental: enable this only if you need
+                    to]
+                </label>
+            {/if}
         </Card>
     </Card>
 </div>

--- a/extension/code/vite/src/lib/Settings/SettingsContainer.ts
+++ b/extension/code/vite/src/lib/Settings/SettingsContainer.ts
@@ -15,7 +15,8 @@ let Settings = writable({
         get_link_by_filter: true, // Get the website link by inspecting all the links in the container div, instead of looking for data references.
         check_nullish_link: true, // Check if a link is nullish and, if true, try with the next video.
         log_link_error: true, // Write in the console if there's an error when fetching the link.
-        maximum_downloads: Infinity // Change this to a finite number to fetch only a specific number of values. Note that a) more elements might be added to the final file if available; and b) "get_array_after_scroll" must be set to false.
+        maximum_downloads: Infinity, // Change this to a finite number to fetch only a specific number of values. Note that a) more elements might be added to the final file if available; and b) "get_array_after_scroll" must be set to false.
+        delete_from_dom: false // Automatically delete the added items from the DOM. This works only if "get_array_after_scroll" is disabled. This is suggested only if you need to download a page with lots of videos
     },
     __extension: {
         fileName: ""


### PR DESCRIPTION
This is a optional setting, that is disabled by default, and might break TikTok's page in the future. Use it only if you need to.

From: https://github.com/Dinoosauro/tiktok-to-ytdlp/issues/21